### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,6 +6,8 @@ jobs:
   test:
     name: Lint
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
     strategy:
       matrix:
         os: [ubuntu-latest]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,8 @@ on:
 
 jobs:
   goreleaser:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   goreleaser:
     permissions:
-      contents: read
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,6 @@
 name: Go Test
+permissions:
+  contents: read
 
 on: [push]
 


### PR DESCRIPTION
Potential fix for [https://github.com/elfranne/sensu-tor-check/security/code-scanning/3](https://github.com/elfranne/sensu-tor-check/security/code-scanning/3)

To address the problem, add a `permissions` block at the job-level (under `goreleaser:`) or at the workflow root to limit the permissions of the GITHUB_TOKEN. The minimal necessary permission for most steps is `contents: read`, but GoReleaser typically requires `contents: write` in order to create GitHub releases or upload assets. However, per the static analysis recommendation, a minimal starting point is `contents: read`, and this should be the default unless specific steps are known to require write access. Therefore, add:

```yaml
permissions:
  contents: read
```

directly under `jobs: goreleaser:`, before `runs-on:` (typically at line 10). If you later find GoReleaser or any subsequent steps require additional permissions (e.g., `contents: write`, `packages: write`, `pull-requests: write`), those can be added with least privileges required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
